### PR TITLE
Coordinate interval update

### DIFF
--- a/gamd/config.py
+++ b/gamd/config.py
@@ -235,6 +235,7 @@ class OutputsReportingConfig:
         assign_tag(xml_energy_tags, "interval", self.energy_interval)
         xml_coordinates_tags = ET.SubElement(root, "coordinates")
         assign_tag(xml_coordinates_tags, "file-type", self.coordinates_file_type)
+        assign_tag(xml_coordinates_tags, "interval", self.coordinates_interval)
         xml_statistics_tags = ET.SubElement(root, "statistics")
         assign_tag(xml_statistics_tags, "interval", self.statistics_interval)
         return

--- a/gamd/gamdSimulation.py
+++ b/gamd/gamdSimulation.py
@@ -8,6 +8,7 @@ GaMD simulation.
 """
 import os
 
+import mdtraj
 import parmed
 import openmm as openmm
 import openmm.app as openmm_app
@@ -25,7 +26,10 @@ from gamd.integrator_factory import *
 
 
 def load_pdb_positions_and_box_vectors(pdb_coords_filename, need_box):
-    positions = openmm_app.PDBFile(pdb_coords_filename)
+    try:
+        positions = openmm_app.PDBxFile(pdb_coords_filename) # More consistency with large systems
+    except:
+        positions = openmm_app.PDBFile(pdb_coords_filename)
     pdb_parmed = parmed.load_file(pdb_coords_filename)
     if need_box:
         assert pdb_parmed.box_vectors is not None, "No box vectors "\
@@ -265,7 +269,8 @@ class GamdSimulationFactory:
 
         elif config.outputs.reporting.coordinates_file_type == "pdb":
             gamdSimulation.traj_reporter = openmm_app.PDBReporter
-
+        elif config.outputs.reporting.coordinates_file_type == "h5":
+            gamdSimulation.traj_reporter = mdtraj.reporters.HDF5Reporter
         else:
             raise Exception("Reporter type not found:",
                             config.outputs.reporting.coordinates_file_type)

--- a/gamd/parser.py
+++ b/gamd/parser.py
@@ -318,6 +318,9 @@ def parse_outputs_tag(tag):
                         if coordinates_tag.tag == "file-type":
                             outputs_config.reporting.coordinates_file_type \
                                 = assign_tag(coordinates_tag, str).lower()
+                        elif coordinates_tag.tag == "interval":
+                            outputs_config.reporting.coordinates_interval \
+                                = assign_tag(coordinates_tag, int)
                         else:
                             print("Warning: parameter in XML not found in "
                                   "coordinates tag. Spelling error?", 

--- a/gamd/runners.py
+++ b/gamd/runners.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 import sys
 
+import mdtraj
 import openmm.unit as unit
 import openmm.app as openmm_app
 
@@ -248,6 +249,9 @@ class Runner:
                 traj_name, self.config.outputs.reporting.coordinates_interval,
                 append=traj_append))
         elif traj_reporter == openmm_app.PDBReporter:
+            simulation.reporters.append(traj_reporter(
+                traj_name, self.config.outputs.reporting.coordinates_interval))
+        elif traj_reporter == mdtraj.reporters.HDF5Reporter:
             simulation.reporters.append(traj_reporter(
                 traj_name, self.config.outputs.reporting.coordinates_interval))
 

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
 
     # Additional entries you may want simply uncomment the lines you want and fill in the data
     # url='http://www.my_package.com',  # Website
-    install_requires=["numpy", "parmed", "pytest", "matplotlib"], 
+    install_requires=["numpy", "parmed", "pytest", "matplotlib", "mdtraj"], 
     # Required packages, pulls from pip if needed; do not use for Conda deployment
     # platforms=['Linux',
     #            'Mac OS-X',


### PR DESCRIPTION
## Description
This PR provides two improvements and one bug fix. 

The first improvement is the addition of a `coordinates_interval` tag to the outputs_config.reporting config, so that the user can specify the output coordinate interval in the xml input file. 

The second improvement was allowing the use of the mdtraj HDF5Reporter as a coordinate output file type. This file type is more space efficient than the PDB format, while still containing the topology. See [https://mdtraj.org/1.9.4/api/generated/mdtraj.reporters.HDF5Reporter.html#:~:text=HDF5Reporter%20stores%20a%20molecular%20dynamics,be%20stored%20in%20the%20file.](link). 

The last change modifies the loading of PDB position using `openmm_app.PDBxFile()` install of `openmm_app.PDBFile()` which allows for more reproducible system handling of large systems with more than 99999 atoms.