### PR TITLE
Update versioneer.py

### DIFF
--- a/versioneer.py
+++ b/versioneer.py
@@ -339,9 +339,11 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
+    # had to modify as python 3.12 no longer accepts SafeConfigParser
+    parser = configparser.ConfigParser()
     with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+      # modfiy to update for python 3.12
+      parser.read_file(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):


### PR DESCRIPTION
Since python 3.12, SafeConfigParser and parser.readfp are deprecated. Need to change to the following: SafeConfigParser = ConfigParser and readfp = read_file

## Description
versioneer needed to be updated to stay consistent with python >= 3.12.

## Todos
Notable points that this PR has either accomplished or will accomplish.
```
    # had to modify as python 3.12 no longer accepts SafeConfigParser
    # parser = configparser.SafeConfigParser()
    parser = configparser.ConfigParser()
    with open(setup_cfg, "r") as f:
        # modfiy to update for python 3.12
        parser.read_file(f)
        # parser.readfp(f)
```

## Questions
- [ ] Question1

## Status
- [ ] Ready to go